### PR TITLE
Add overwrite flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "imgorisort"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["🎷🐛 Lee Ball <lee.cat.ball@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,6 +19,7 @@ aho-corasick = "^0.7.13"
 arraystring = "0.3.0"
 clap = "^2.33.1"
 image = { version = "^0.23.6", features = ["gif", "jpeg", "ico", "png", "tiff", "webp", "bmp", "jpeg_rayon"] }
+lazy_static = "^1.4.0"
 log = "^0.4.8"
 stderrlog = "^0.4.3"
 structopt = "^0.3.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "imgorisort"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["🎷🐛 Lee Ball <lee.cat.ball@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This small tool's first release includes only the basic functionality: move imag
 
 ### Move images
 
-Move images to 'tall', 'wide', and 'square' directories.
+Move images to 'tall', 'wide', and 'square' directories. Use --overwrite if these directories exist, and you want files with the same name to overwrite files in destination directories instread of appending a number to the name.
 
 ```
 $ tree /path/to/images
@@ -70,7 +70,7 @@ $ tree /path/to/images
 Run `imgorisort --help` to see the usage text:
 
 ```
-imgorisort 0.2.0
+imgorisort 0.3.0
 Image Orientation Sorter
 
 USAGE:
@@ -78,11 +78,13 @@ USAGE:
 
 FLAGS:
     -h, --help         Prints help information
+        --overwrite    Overrwite files in the destination directory if file names are the same. Without this flag set,
+                       the default behavior is to append a number to make the filename unique.
     -q, --quiet        Do not print anything to stdout or stderr.
     -r, --recursive    Recurse into subdirectories.
         --rename       Prepend image orientation to filename instead of moving file.
     -V, --version      Prints version information
-    -v, --verbose      Increase output verbosity by adding more flags: [-v|-vv|-vvv]
+    -v, --verbose      Increase output verbosity by adding more flags: [-v|-vv|-vvv|-vvvv|-vvvvv]
 
 ARGS:
     <input-dir>     Directory containing image files to sort by orientation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate lazy_static;
+#[macro_use] extern crate log;
 extern crate stderrlog;
 
+use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 use arraystring::{ArrayString, typenum::U4};
-use aho_corasick::AhoCorasickBuilder;
 use image::image_dimensions;
 use std::cmp::Ordering;
 use std::fs::{create_dir_all, rename};
@@ -24,6 +24,24 @@ impl Orientation {
     }
 }
 
+lazy_static! {
+    static ref AC: AhoCorasick = unsafe {
+        AhoCorasickBuilder::new()
+            .dfa(true)
+            .byte_classes(false)
+            .ascii_case_insensitive(true)
+            .build(&[
+                FourChar::from_str_unchecked("jpg"),
+                FourChar::from_str_unchecked("jpeg"),
+                FourChar::from_str_unchecked("png"),
+                FourChar::from_str_unchecked("gif"),
+                FourChar::from_str_unchecked("webp"),
+                FourChar::from_str_unchecked("ico"),
+                FourChar::from_str_unchecked("tiff"),
+                FourChar::from_str_unchecked("bmp"),])
+    };
+}
+
 #[derive(Debug, StructOpt)]
 #[structopt(name = "imgorisort", about = "Image Orientation Sorter")]
 struct Opt {
@@ -35,10 +53,12 @@ struct Opt {
     recursive: bool,
     #[structopt(long, help = "Prepend image orientation to filename instead of moving file.")]
     rename: bool,
-    #[structopt(short, long, parse(from_occurrences), help = "Increase output verbosity by adding more flags: [-v|-vv|-vvv]")]
+    #[structopt(short, long, parse(from_occurrences), help = "Increase output verbosity by adding more flags: [-v|-vv|-vvv|-vvvv|-vvvvv]")]
     verbose: usize,
     #[structopt(short, long, help = "Do not print anything to stdout or stderr.")]
     quiet: bool,
+    #[structopt(long, help = "Overrwite files in the destination directory if file names are the same. Without this flag set, the default behavior is to append a number to make the filename unique.")]
+    overwrite: bool,
 }
 
 fn main() -> std::io::Result<()> {
@@ -50,9 +70,9 @@ fn main() -> std::io::Result<()> {
     };
     let images = image_paths(&opts);
     let dests = get_dsts(&opts, &images);
-    let num_moved = mv_files(&images, dests);
+    let moved: u32 = mv_files(&images, dests, &opts);
     if !opts.quiet {
-        println!("Processed {} files successfully.", num_moved);
+        println!("Processed {} files successfully.", moved);
     }
     Ok(())
 }
@@ -98,17 +118,13 @@ fn image_paths(opts: &Opt) -> Vec<PathBuf> {
         .max_depth(max_depth)
         .into_iter()
         .filter_map( |dir| dir.ok() )
-        .filter( |dir| {
-            trace!("Checking extension for {:?}", dir ) ;
-            has_image_extension(dir.path())
-        })
+        .filter( |dir| dir.file_type().is_file() && has_image_extension(dir.path()) )
         .map( |dir| dir.into_path() )
         .collect()
 }
 
 /// Given a set of image paths, find where they should be moved to (including in-place renaming).
-///
-/// Source files with a destination of None will not be acted upon.
+#[inline]
 fn get_dsts(opts: &Opt, imgs: &Vec<PathBuf>) -> Vec<Option<PathBuf>> {
     imgs.iter()
         .map(|img| dst_path(opts, img))
@@ -116,6 +132,7 @@ fn get_dsts(opts: &Opt, imgs: &Vec<PathBuf>) -> Vec<Option<PathBuf>> {
 }
 
 /// Find destination path based on image orientation.
+#[inline]
 fn dst_path(opts: &Opt, img_path: &Path) -> Option<PathBuf> {
     let imgfile = img_path.file_name().unwrap();
     let ori: Orientation = match image_orientation(img_path) {
@@ -124,43 +141,51 @@ fn dst_path(opts: &Opt, img_path: &Path) -> Option<PathBuf> {
     };
     match opts.rename {
         true => match prepend_orientation(img_path) {
-            Some(renamed) => {
-                trace!("Rename {:?} to {:?}", img_path, renamed);
-                Some(renamed)
-            },
+            Some(renamed) => Some(renamed),
             None => return None
         },
         false => {
             let mut out = opts.output_dir.to_owned();
             out.push(ori.to_arrstr().as_str());
             out.push(imgfile);
-            trace!("Move {:?} to {:?}", img_path, out);
+            if out.as_path() == img_path {
+                drop(out);
+                debug!("File already in destination, skipping. {:?}", img_path);
+                return None
+            };
             Some(out)
         },
     }
 }
 
 /// Iterate source and destination path vectors, moving matching indexes.
-fn mv_files(src_paths: &Vec<PathBuf>, dst_paths: Vec<Option<PathBuf>>) -> u16 {
+// TODO: Break these long filters/maps into functions.
+fn mv_files(src_paths: &Vec<PathBuf>, dst_paths: Vec<Option<PathBuf>>, opts: &Opt) -> u32 {
     if src_paths.len() != dst_paths.len() {
-        // TODO: While this hopefully won't happen if all errors are propagated forward as Nones,
-        //       consider writing function to normalize src & dst vectors based on path similarity.
-        // TODO: Be sure to test this case when writing tests.
-        panic!("Source files do not match calculated destination files.");
+        panic!("Source files do not match calculated destination files.\nSource files: {:?}\nDestinations: {:?}", src_paths, dst_paths);
     }
     src_paths
         .iter()
         .zip(dst_paths.iter())
+        .filter( |sd| !sd.1.is_none() )
         .filter_map( |sd| {
-            match sd.1.is_none() {
-                true => None,
-                false => Some(sd),
+            let dst = sd.1.to_owned().unwrap();
+            if !opts.overwrite {
+                if dst.exists() {
+                    Some( (sd.0, make_uniq(dst)) )
+                } else {
+                    Some( (sd.0, dst) )
+                }
+            } else {
+                Some( (sd.0, dst) )
             }
         })
         .map( |sd| {
-            trace!("Attempting fs::rename on {:?}", sd);
-            match rename(&sd.0, sd.1.as_ref().unwrap() ) {
-                Ok(_) => 1,
+            match rename(&sd.0, &sd.1) {
+                Ok(_) => {
+                    debug!("Moved {:?} to {:?}", &sd.0, &sd.1);
+                    1
+                },
                 Err(e) => {
                     error!("Failed to move\n  {:?}\nto\n  {:?}\nError: {:?}.", sd.0, sd.1, e);
                     0
@@ -171,8 +196,9 @@ fn mv_files(src_paths: &Vec<PathBuf>, dst_paths: Vec<Option<PathBuf>>) -> u16 {
 }
 
 /// Determine the orientation of an image.
+#[inline]
 fn image_orientation(img_path: &Path) -> Option<Orientation> {
-    let (x, y) = match image_dimensions(img_path) {
+    let (x, y): (u32, u32) = match image_dimensions(img_path) {
         Ok(xy) => {xy},
         Err(e) => {
             warn!("Error finding orientation of image: {:?}. Image will not be moved or renamed. Error: {:?}", img_path, e);
@@ -180,60 +206,69 @@ fn image_orientation(img_path: &Path) -> Option<Orientation> {
         }
     };
     match x.cmp(&y) {
-        Ordering::Less    => { Some(Orientation::Wide) },
-        Ordering::Greater => { Some(Orientation::Tall) },
+        Ordering::Less    => { Some(Orientation::Tall) },
+        Ordering::Greater => { Some(Orientation::Wide) },
         Ordering::Equal   => { Some(Orientation::Square) },
     }
 }
 
 /// Prepend the image orientation to its filename.
 fn prepend_orientation(p: &Path) -> Option<PathBuf> {
-    let mut name = p.to_owned();
-    let ori = match image_orientation(p) {
+    let ori: Orientation = match image_orientation(p) {
         Some(ori) => ori,
         None => return None
     };
-    name.set_file_name(
+
+    let mut new_name = p.to_owned();
+    new_name.set_file_name(
         format!(
             "{}_{}",
             ori.to_arrstr().as_str(),
-            p.file_name().unwrap().to_str().unwrap()
-        )
-    );
-    Some(name)
+            p.file_name().unwrap().to_str().unwrap()));
+
+    if new_name.as_path() != p {
+        if new_name.exists() {
+            new_name = make_uniq(new_name);
+        }
+        trace!("Renamed {:?} to {:?}", p, new_name);
+        Some(new_name)
+    } else {
+        error!("Rename failed. Rename operation produced identical paths. {:?}, {:?}", new_name.file_name(), p.file_name());
+        None
+    }
+}
+
+/// Try to make a filename unique by appending an integer to the end of a filename.
+// TODO: Do this smarter and/or allow user to configure alternative suffix (timestamp? uuid?)
+#[inline]
+#[cold]
+fn make_uniq(fpath: PathBuf) -> PathBuf {
+    let mut i: u16 = 0;
+    let mut new_name: PathBuf = fpath.to_owned();
+    while new_name.exists() {
+        i += 1;
+        new_name.set_file_name(
+            format!("{}_{}.{}",
+                new_name.file_stem().unwrap().to_str().unwrap(),
+                i,
+                new_name.extension().unwrap().to_str().unwrap()));
+    }
+    drop(i);
+    trace!("Renamed file to: {:?}", fpath);
+    new_name
 }
 
 /// Return true if the given path has an image file extension.
+#[inline]
 fn has_image_extension(path: &Path) -> bool {
-    let extension = match path.extension() {
+    let extension: &str = match path.extension() {
         Some(extension) => match extension.to_str() {
-            Some(extension) => {
-                trace!("{:?} has extension {:?}", path, extension);
-                extension
-            },
-            None => {
-                trace!("{:?} has no extension str.", path);
-                return false
-            },
+            Some(extension) => extension,
+            None => return false,
         },
-        None => {
-            trace!("{:?} has no extension.", path); return false
-        }
+        None => return false
     };
-    let ac = unsafe {
-        AhoCorasickBuilder::new()
-            .dfa(true)
-            .byte_classes(false)
-            .ascii_case_insensitive(true)
-            .build(&[
-                FourChar::from_str_unchecked("jpg"),
-                FourChar::from_str_unchecked("jpeg"),
-                FourChar::from_str_unchecked("png"),
-                FourChar::from_str_unchecked("gif"),
-                FourChar::from_str_unchecked("webp"),
-                FourChar::from_str_unchecked("ico"),
-                FourChar::from_str_unchecked("tiff"),
-                FourChar::from_str_unchecked("bmp"),]) };
-    trace!{"Image extension matched: {:?}", ac.is_match(extension)}
-    ac.is_match(extension)
+    let is_img: bool = AC.is_match(extension);
+    debug!("{:?} is an image? -> {:?}", path, is_img);
+    is_img
 }


### PR DESCRIPTION
Add overwrite flag, allowing use to specify they wish to overwrite
any file in the destination with the same name as the source file.

By default, if a file with the same name as the source exists in the
destination directory, a number will be appended to the file to make
the filename unique.

This commit includes some refactoring including removing extra debug
messages, adding inline and cold attributes to functions, and the addition
of the lazy_static crate for a static Aho-Corasick file extension matcher.